### PR TITLE
Update retired model id in the llm-application-dev skill

### DIFF
--- a/skills/llm-application-dev/SKILL.md
+++ b/skills/llm-application-dev/SKILL.md
@@ -86,7 +86,7 @@ const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 async function chat(prompt: string): Promise<string> {
   const response = await anthropic.messages.create({
-    model: 'claude-3-opus-20240229',
+    model: 'claude-opus-4-8',
     max_tokens: 1024,
     messages: [{ role: 'user', content: prompt }],
   });


### PR DESCRIPTION
`skills/llm-application-dev/SKILL.md` shows an Anthropic call whose model id no longer resolves. A reader who copies the snippet gets a model the API stopped serving on 5 January 2026, per the [Anthropic deprecations page](https://platform.claude.com/docs/en/about-claude/model-deprecations).

| File | Line | Was | Now |
| --- | --- | --- | --- |
| `skills/llm-application-dev/SKILL.md` | 89 | `claude-3-opus-20240229` | `claude-opus-4-8` |

`claude-opus-4-8` is the current Opus. If you would rather point the example at something cheaper for a docs snippet, `claude-haiku-4-5` reads just as well and I will change it.

That is the only retired Claude id in the repo. I grepped the other 16 skills and the `gpt-4` and Gemini examples in the same file, and left those alone since they are not mine to judge.

One thing you may want to look at separately. The frontmatter of this skill carries `source: wshobson/agents`, and a code search across that repo turns up `claude-3-opus-20240229` only in `tools/tests/test_adapters.py`, not in a skill file. So the vendored copy here may have drifted from upstream in other ways too. I have not diffed the two, that is just what the search showed.

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. I have not run the snippet against the API to reproduce a failure, the claim rests on the published retirement date. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
