### PR TITLE
feat: add you-web skill from youdotcom-oss/agent-skills to the catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
   <a href="https://github.com/MoizIbnYousaf/Ai-Agent-Skills"><img alt="GitHub stars" src="https://img.shields.io/github/stars/MoizIbnYousaf/Ai-Agent-Skills?style=for-the-badge&label=stars&labelColor=313244&color=89b4fa&logo=github&logoColor=cdd6f4" /></a>
   <a href="https://www.npmjs.com/package/ai-agent-skills"><img alt="npm version" src="https://img.shields.io/npm/v/ai-agent-skills?style=for-the-badge&label=version&labelColor=313244&color=b4befe&logo=npm&logoColor=cdd6f4" /></a>
   <a href="https://www.npmjs.com/package/ai-agent-skills"><img alt="npm total downloads" src="https://img.shields.io/npm/dt/ai-agent-skills?style=for-the-badge&label=downloads&labelColor=313244&color=f5e0dc&logo=npm&logoColor=cdd6f4" /></a>
-  <a href="https://github.com/MoizIbnYousaf/Ai-Agent-Skills#shelves"><img alt="Library structure" src="https://img.shields.io/badge/library-140%20skills%20%C2%B7%206%20shelves-cba6f7?style=for-the-badge&labelColor=313244&logo=bookstack&logoColor=cdd6f4" /></a>
+  <a href="https://github.com/MoizIbnYousaf/Ai-Agent-Skills#shelves"><img alt="Library structure" src="https://img.shields.io/badge/library-141%20skills%20%C2%B7%206%20shelves-cba6f7?style=for-the-badge&labelColor=313244&logo=bookstack&logoColor=cdd6f4" /></a>
 </p>
 
-<p align="center"><sub>17 house copies · 123 cataloged upstream</sub></p>
+<p align="center"><sub>17 house copies · 124 cataloged upstream</sub></p>
 <!-- GENERATED:library-stats:end -->
 
 <p align="center"><em>Picked, shelved, and maintained by hand.</em></p>
@@ -236,7 +236,7 @@ The shelves are the main structure.
 | Frontend | 10 | Interfaces, design systems, browser work, and product polish. |
 | Backend | 5 | Systems, data, security, and runtime operations. |
 | Mobile | 24 | Swift, SwiftUI, iOS, and Apple-platform development, with room for future React Native branches. |
-| Workflow | 11 | Files, docs, planning, release work, and research-to-output flows. |
+| Workflow | 12 | Files, docs, planning, release work, and research-to-output flows. |
 | Agent Engineering | 14 | MCP, skill-building, prompting discipline, and LLM application work. |
 | Marketing | 76 | Brand, strategy, copy, distribution, creative, SEO, conversion, and growth work. |
 <!-- GENERATED:shelf-table:end -->
@@ -334,6 +334,7 @@ Current upstream mix:
 | `twostraws/SwiftData-Agent-Skill` | 1 |
 | `twostraws/SwiftUI-Agent-Skill` | 1 |
 | `vanab/swiftdata-agent-skill` | 1 |
+| `youdotcom-oss/agent-skills` | 1 |
 <!-- GENERATED:source-table:end -->
 
 The two biggest upstream publishers in this library are Anthropic and OpenAI.

--- a/WORK_AREAS.md
+++ b/WORK_AREAS.md
@@ -48,7 +48,7 @@ House copies stay flat under `skills/<name>/`. The catalog holds the real struct
 
 ## Workflow
 
-11 skills. Files, docs, planning, release work, and research-to-output flows.
+12 skills. Files, docs, planning, release work, and research-to-output flows.
 
 | Branch | Skills | Source |
 | --- | --- | --- |
@@ -56,7 +56,7 @@ House copies stay flat under `skills/<name>/`. The catalog holds the real struct
 | Planning | `linear`, `notion-spec-to-implementation` | openai |
 | Release | `changelog-generator` | composio |
 | Release & Sharing | `share-a-library` | MoizIbnYousaf |
-| Research & Writing | `content-research-writer` | composio |
+| Research & Writing | `content-research-writer`, `you-web` | composio, youdotcom-oss |
 
 ## Agent Engineering
 

--- a/skills.json
+++ b/skills.json
@@ -1,7 +1,7 @@
 {
   "version": "4.3.2",
-  "updated": "2026-08-17",
-  "total": 140,
+  "updated": "2026-09-07",
+  "total": 141,
   "workAreas": [
     {
       "id": "frontend",
@@ -4553,6 +4553,40 @@
       "distribution": "live",
       "notes": "",
       "labels": []
+    },
+    {
+      "name": "you-web",
+      "description": "Use You.com MCP tools for current web search, URL content extraction, cited web synthesis, and x402-aware web access.",
+      "category": "productivity",
+      "workArea": "workflow",
+      "branch": "Research & Writing",
+      "author": "youdotcom-oss",
+      "source": "youdotcom-oss/agent-skills",
+      "license": "MIT",
+      "tier": "upstream",
+      "distribution": "live",
+      "vendored": false,
+      "installSource": "youdotcom-oss/agent-skills/skills/you-web",
+      "requires": [],
+      "tags": [
+        "web-search",
+        "mcp",
+        "you.com",
+        "research"
+      ],
+      "featured": false,
+      "verified": false,
+      "origin": "curated",
+      "trust": "listed",
+      "syncMode": "live",
+      "sourceUrl": "https://github.com/youdotcom-oss/agent-skills/tree/main/skills/you-web",
+      "whyHere": "Covers cited web search and URL content extraction through the You.com MCP server, filling the web-research gap on the Research & Writing branch.",
+      "lastVerified": "",
+      "notes": "",
+      "labels": [],
+      "addedDate": "2026-09-07",
+      "lastCurated": "2026-09-07T00:00:00Z",
+      "path": ""
     }
   ]
 }


### PR DESCRIPTION
Adds the `you-web` skill from [youdotcom-oss/agent-skills](https://github.com/youdotcom-oss/agent-skills) to the catalog as an upstream live entry — no vendored copy, sparse-checkout install from the source repo, exactly like the other 123 upstream entries.

**Why it belongs here:** the Research & Writing branch on the Workflow shelf currently has `content-research-writer` for turning research into drafts, but nothing that covers current web search, URL content extraction, and cited synthesis as a capability. `you-web` fills that gap — it routes agents to the You.com MCP server (`https://api.you.com/mcp`) for `you-search`, `you-contents`, and `you-research`, with cited output. It is reusable across any project where answers depend on current web information, which fits the "genuinely useful in real work" bar in CURATION.md.

**What changed:**
- `skills.json`: one new upstream entry (`you-web`, workArea `workflow`, branch `Research & Writing`, trust `listed`, syncMode `live`, tags `web-search`, `mcp`, `you.com`, `research`)
- `README.md` / `WORK_AREAS.md`: generated stats/source/shelf tables re-rendered with the repo's own tooling

I added this with the repo's own flow:

```bash
npx ai-agent-skills catalog youdotcom-oss/agent-skills --skill you-web \
  --area workflow --branch "Research & Writing" --category productivity \
  --trust listed --tags "web-search,mcp,you.com,research" \
  --why "Covers cited web search and URL content extraction through the You.com MCP server, filling the web-research gap on the Research & Writing branch."
```

**Validation:**
- `node test.js`: 225 passed / 3 failed — the same 3 tests fail on `main` without this change (verified by re-running the suite on a clean checkout), so no new failures.
- `node scripts/validate.js`: passed — 141 skills, all required fields, collections valid, generated docs in sync (the one warning is pre-existing on `tiktok-slideshow`).
- End-to-end: `npx ai-agent-skills install you-web` clones `youdotcom-oss/agent-skills/skills/you-web` via sparse checkout and installs `SKILL.md` + references correctly; `search` / `info` / `preview` all resolve the entry.

No collection membership — tags and search do the job here, per the CONTRIBUTING guidance. Happy to adjust placement (shelf/branch/category) if you'd file it differently, or drop it entirely if it feels too close to the marketing pack's Exa skills — those are Exa-API-specific and marketing-shelved, so I read this as complementary rather than overlapping, but your call.
